### PR TITLE
update link to google python style guide

### DIFF
--- a/style-guides.md
+++ b/style-guides.md
@@ -4,7 +4,7 @@
 
     Official recommendations.
 
--   [Google Python Style Guide](https://google-styleguide.googlecode.com/svn/trunk/pyguide.html)
+-   [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html)
 
     Since Google is a heavy Python user, this one should be very good.
 


### PR DESCRIPTION
In 2016 the service googlecode was shut down, see https://opensource.googleblog.com/2015/03/farewell-to-google-code.html for more info.



--
hey, I've seen your post on HN, I wandered a bit on your creations (impressive !), and I stumbled upon this, so I thought I would give you some minor help here =)
